### PR TITLE
permit compilation under Eigen 3.4.0

### DIFF
--- a/src/MatOp.h
+++ b/src/MatOp.h
@@ -131,7 +131,7 @@ template<class MatType, class RowIndexType>
 inline void set_Row(MatType& F, const MatType& fi, const RowIndexType& ix, int i) {
   int s = fi.rows();
   for(int j = 0; j < s; j++) {
-    F(ix(j) - 1, i) = fi(j, 0);
+    F(static_cast<int>(ix(j) - 1), i) = fi(j, 0);
   }
 }
 
@@ -140,7 +140,7 @@ template<class MatType, class ColIndexType>
 inline void set_Col(MatType& F, const MatType& fi, const ColIndexType& ix, int i) {
   int s = fi.rows();
   for(int j = 0; j < s; j++) {
-    F(i, ix(j) - 1) = fi(j, 0);
+    F(i, static_cast<int>(ix(j) - 1)) = fi(j, 0);
   }
 }
 


### PR DESCRIPTION
Dear Xin Zhou, dear fssemR team,

Eigen 3.4.0 was released earlier in the year, and I have been asked to update RcppEigen to it.  As documented [in this issue at its GitHub repo](https://github.com/RcppCore/RcppEigen/issues/103), there are about 10 packages that built at CRAN under the previous release, but not with the Eigen 3.4.0 changes in the release candidate package -- which can be installed via

    install.packages("RcppEigen", repo="https://RcppCore.github.io/drat")

For fssemR, the change is fairly simple. Apparently Eigen 3.4.0 gets confused from Eigen objects used as matrix indices.  With the simple changes in this PR,  the package installs for me.

It would be helpful for RcppEigen if you could apply the patch and release an updated version so that RcppEigen could be upgraded to a version with Eigen 3.4.0.

Let me know if you have any question, and please do not hesitate to reply and ask.

Cheers,  Dirk  (who looks after RcppEigen ...)

